### PR TITLE
Save config

### DIFF
--- a/device_connector.py
+++ b/device_connector.py
@@ -131,9 +131,27 @@ class device_connector:
     def send_config_set(self, set_list):
 
         if self.device_type == 'juniper_junos':
-            return self.device_connection.send_config_set(set_list, config_mode_command='configure exclusive')
+            return self.device_connection.send_config_set(set_list, exit_config_mode=False, config_mode_command='configure exclusive')
+        elif self.device_type == 'cisco_ios':
+            return self.device_connection.send_config_set(set_list, exit_config_mode=True)
+        elif self.device_type == 'hp_procurve':
+            return self.device_connection.send_config_set(set_list, exit_config_mode=True)
         else:
-            return self.device_connection.send_config_set(set_list)
+            pass
+
+    def save_config_and_exit(self):
+
+        buf = ""
+        if self.device_type == 'juniper_junos':
+            buf += self.device_connection.commit(and_quit=True)
+        elif self.device_type == 'cisco_ios':
+            buf += self.device_connection.save_config()
+        elif self.device_type == 'hp_procurve':
+            buf += self.device_connection.save_config()
+        else:
+            pass
+        buf += self.device_connection.exit_config_mode()
+        return buf
         
     def disconnect(self):
         

--- a/device_connector.py
+++ b/device_connector.py
@@ -136,20 +136,28 @@ class device_connector:
             return self.device_connection.send_config_set(set_list, exit_config_mode=True)
         elif self.device_type == 'hp_procurve':
             return self.device_connection.send_config_set(set_list, exit_config_mode=True)
+        elif self.device_type == 'sentry_pdu':
+            return self.device_connection.send_config_set(set_list, exit_config_mode=False)
         else:
             pass
 
     def save_config_and_exit(self):
 
         buf = ""
-        if self.device_type == 'juniper_junos':
-            buf += self.device_connection.commit(and_quit=True)
-        elif self.device_type == 'cisco_ios':
-            buf += self.device_connection.save_config()
-        elif self.device_type == 'hp_procurve':
-            buf += self.device_connection.save_config()
-        else:
-            pass
+        try:
+            if self.device_type == 'juniper_junos':
+                buf += self.device_connection.commit(and_quit=True)
+            elif self.device_type == 'cisco_ios':
+                buf += self.device_connection.save_config()
+            elif self.device_type == 'hp_procurve':
+                buf += self.device_connection.save_config()
+            elif self.device_type == 'sentry_pdu':
+                buf += self.device_connection.save_config()
+            else:
+                pass
+        except NotImplementedError:  # e.g. sentry_pdu uses netmiko's accedian device and it doesn't impl save_config
+            return buf
+
         buf += self.device_connection.exit_config_mode()
         return buf
         

--- a/device_connector.py
+++ b/device_connector.py
@@ -138,25 +138,33 @@ class device_connector:
             return self.device_connection.send_config_set(set_list, exit_config_mode=True)
         elif self.device_type == 'sentry_pdu':
             return self.device_connection.send_config_set(set_list, exit_config_mode=False)
+        elif self.device_type == 'paloalto_panos':
+            try:
+                return self.device_connection.send_config_set(set_list, exit_config_mode=False)
+            except OSError:
+                return "Did not find expected pattern. Likely nothing to commit!"
         else:
             pass
 
     def save_config_and_exit(self):
 
         buf = ""
-        try:
-            if self.device_type == 'juniper_junos':
-                buf += self.device_connection.commit(and_quit=True)
-            elif self.device_type == 'cisco_ios':
+
+        if self.device_type == 'juniper_junos':
+            buf += self.device_connection.commit(and_quit=True)
+        elif self.device_type == 'cisco_ios':
+            buf += self.device_connection.save_config()
+        elif self.device_type == 'hp_procurve':
+            buf += self.device_connection.save_config()
+        elif self.device_type == 'sentry_pdu':
+            try: # e.g. sentry_pdu uses netmiko's accedian device - it doesn't impl save_config as config is auto-saved
                 buf += self.device_connection.save_config()
-            elif self.device_type == 'hp_procurve':
-                buf += self.device_connection.save_config()
-            elif self.device_type == 'sentry_pdu':
-                buf += self.device_connection.save_config()
-            else:
-                pass
-        except NotImplementedError:  # e.g. sentry_pdu uses netmiko's accedian device and it doesn't impl save_config
-            return buf
+            except NotImplementedError:
+                return buf
+        elif self.device_type == 'paloalto_panos':
+            buf += self.device_connection.commit()
+        else:
+            pass
 
         buf += self.device_connection.exit_config_mode()
         return buf

--- a/swITch.py
+++ b/swITch.py
@@ -213,6 +213,7 @@ class swITch:
                 log.event('verbose', dev.find_prompt() + cmd + "\n")
                 log.event('log_only', dev.send_config_set(list_of_set_cmds) + "\n")  # send command
                 log.event('debug', "DEBUG PROMPT:" + dev.find_prompt() + "\n")
+                log.event('verbose', dev.save_config_and_exit() + "\n")
                 dev.disconnect()
                 log.event('info', "SSH connection closed to " + dev.ip + "\n")
                     


### PR DESCRIPTION
This implements saving/committing of configuration after config commands are issued using the --set flag. Tested to be working for all devices supported.